### PR TITLE
Changed TwigServiceProvider to be more flexible when adding extensions

### DIFF
--- a/src/ServiceProvider/TwigServiceProvider.php
+++ b/src/ServiceProvider/TwigServiceProvider.php
@@ -77,8 +77,10 @@ class TwigServiceProvider extends AbstractServiceProvider implements BootableSer
         $added = [];
 
         foreach ($extensions as $extension) {
-            $this->getContainer()->add($extension);
-            $added[] = $extension;
+            $alias = is_string($extension) ? $extension : get_class($extension);
+
+            $this->getContainer()->add($alias);
+            $added[] = $alias;
         }
 
         return $added;

--- a/src/ServiceProvider/TwigServiceProvider.php
+++ b/src/ServiceProvider/TwigServiceProvider.php
@@ -77,9 +77,9 @@ class TwigServiceProvider extends AbstractServiceProvider implements BootableSer
         $added = [];
 
         foreach ($extensions as $extension) {
-            $alias = is_string($extension) ? $extension : get_class($extension);
+            $alias = (is_string($extension)) ? $extension : get_class($extension);
 
-            $this->getContainer()->add($alias);
+            $this->getContainer()->add($alias, $extension);
             $added[] = $alias;
         }
 


### PR DESCRIPTION
You can now register objects as well as string aliases.

allows you to use dependency injection inside twig extensions.
